### PR TITLE
Add more defense questions and one about auto

### DIFF
--- a/2022/RR_config.js
+++ b/2022/RR_config.js
@@ -111,6 +111,11 @@ var config_data = `
         "title": "Def: Opponent Missed Shot",
         "type":"counter"
       },
+      "Def: Pinned Opponent<br>(More than 3 seconds)": {
+        "code":"dp",
+        "title": "Def: Pinned Opponent<br>(More than 3 seconds)",
+        "type":"counter"
+      },
       "Upper Cargo Scored": {
         "code":"tu",
         "title": "Uppoer Cargo Scored",

--- a/2022/RR_config.js
+++ b/2022/RR_config.js
@@ -101,26 +101,6 @@ var config_data = `
       }
     },
     "teleop": {
-      "Upper Cargo Scored": {
-        "code":"tu",
-        "title": "Uppoer Cargo Scored",
-        "type":"counter"
-      },
-      "Lower Cargo Scored": {
-        "code":"tl",
-        "title": "Lower Cargo Scored",
-        "type":"counter"
-      },
-      "Was Defended": {
-        "code":"wd",
-        "title": "Was Defended",
-        "type":"bool"
-      },
-      "Wallbot?": {
-        "code":"wbt",
-        "title": "Wallbot?",
-        "type":"bool"
-      },
       "Def: Turned Opponent": {
         "code":"dt",
         "title": "Def: Turned Opponent",
@@ -129,6 +109,16 @@ var config_data = `
       "Def: Opponemt Missed Shot": {
         "code":"dm",
         "title": "Def: Opponent Missed Shot",
+        "type":"counter"
+      },
+      "Upper Cargo Scored": {
+        "code":"tu",
+        "title": "Uppoer Cargo Scored",
+        "type":"counter"
+      },
+      "Lower Cargo Scored": {
+        "code":"tl",
+        "title": "Lower Cargo Scored",
         "type":"counter"
       },
       "Shooting Spot (Both made and missed)": {
@@ -224,6 +214,16 @@ var config_data = `
           "x":"Not Attempted"
         },
         "defaultValue":"x"
+      },
+      "Was Defended": {
+        "code":"wd",
+        "title": "Was Defended",
+        "type":"bool"
+      },
+      "Wallbot?": {
+        "code":"wbt",
+        "title": "Wallbot?",
+        "type":"bool"
       },
       "Died/Tipped": {
         "code":"d",

--- a/2022/RR_config.js
+++ b/2022/RR_config.js
@@ -80,6 +80,20 @@ var config_data = `
         "title": "Lower Cargo Scored",
         "type":"counter"
       },
+      "Auto Attempted": {
+        "code":"aa",
+        "title": "Auto Attempted",
+        "type":"radio",
+        "choices":{
+          "0":"Not Attempted<br>",
+          "1":"1-Cargo<br>",
+          "2":"2-Cargo<br>",
+          "3":"3-Cargo<br>",
+          "4":"4-Cargo<br>",
+          "5":"5-Cargo"
+        },
+        "defaultValue":"0"
+      },
       "Auto Aquired Cargo": {
         "code":"ac",
         "title": "Picked up more cargo?",
@@ -107,19 +121,17 @@ var config_data = `
         "title": "Wallbot?",
         "type":"bool"
       },
-      "Cargo Intake From": {
-        "code":"cif",
-        "title": "Cargo Intake From",
-        "type":"radio",
-        "choices":{
-          "t":"Terminal<br>",
-          "g":"Ground<br>",
-          "b":"Both<br>",
-          "x":"Not Attempted"
-        },
-        "defaultValue":"x"
+      "Def: Turned Opponent": {
+        "code":"dt",
+        "title": "Def: Turned Opponent",
+        "type":"counter"
       },
-      "Shooting Spot": {
+      "Def: Opponemt Missed Shot": {
+        "code":"dm",
+        "title": "Def: Opponent Missed Shot",
+        "type":"counter"
+      },
+      "Shooting Spot (Both made and missed)": {
         "code":"ss",
         "title": "Shooting Spot",
         "type":"field_image",
@@ -201,6 +213,18 @@ var config_data = `
         },
         "defaultValue":"3"
       },
+      "Cargo Intake From": {
+        "code":"cif",
+        "title": "Cargo Intake From",
+        "type":"radio",
+        "choices":{
+          "t":"Terminal<br>",
+          "g":"Ground<br>",
+          "b":"Both<br>",
+          "x":"Not Attempted"
+        },
+        "defaultValue":"x"
+      },
       "Died/Tipped": {
         "code":"d",
         "title": "Died/Tipped",
@@ -226,9 +250,9 @@ var config_data = `
           "v":"Very Confident<br>",
           "a":"Average<br>",
           "n":"Not Confident"
-      },
-       "defaultValue":"a"
-    }
+        },
+        "defaultValue":"a"
+      }
     }
   }
 }`;


### PR DESCRIPTION
Added 3 more questions:
1. Auto Attempted - As best you can judge were they going for a 1-, 2-, 3-, 4-, or 5-cargo auto (need this to pick a good 2-cargo bot to compliment our 5-cargo auto)
2. Def: Opponent Turned - Counter - Increase every time the defender hits and turns a robot stopping to shoot
3. Def: Opponent Missed Shot - Did the opponent miss a shot due to defense (not just a lucky bounce out)
4. Def: Pinned Opponent - Count the number of times the defender pinned a robot and delayed it for more than 3 seconds.

I also re-ordered the questions a little, moving some of the teleop questions to post-match.  This way scouts can focus on the key parts of teleop (offense and defense).

See my version at http://fuddster.github.io/ScoutingPASS.

What do you think?
